### PR TITLE
fix(profiles): strip UTF-8 BOM before parsing HueForge CSV/TSV imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to Kromacut are documented in this file.
 
 ### Fixed
 
+- **HueForge spool CSV/TSV imports** - BOM-prefixed HueForge spool files now import correctly when a UTF-8 byte-order mark precedes the first header.
 - **Settings documentation link** - Opening Docs from Settings now remains in the documentation when Docs is already active instead of unexpectedly returning to the app.
 - **Auto-paint Max Height** - Auto-paint now plans, scores, previews, and exports the same layer-aligned stack. Height caps round down to a valid printable layer boundary, so a generated model no longer exceeds the requested maximum by adding a final whole layer.
 - **Auto-paint region priority** - Center and Edge priority now use the actual locations of each image color. Center prioritizes colors near the image middle; Edge prioritizes colors near the outer border. The optimizer no longer allocates a full-image weight map or guesses location from color brightness.

--- a/src/lib/profileManager.ts
+++ b/src/lib/profileManager.ts
@@ -401,6 +401,11 @@ function parseCSV(content: string, delimiter: ',' | '\t'): string[][] {
  * Quoted fields with embedded commas, newlines, and "" escaped quotes are
  * supported per RFC 4180. Rows missing Color or TD are skipped.
  *
+ * A leading UTF-8 byte-order mark (U+FEFF), often added by spreadsheet
+ * tools such as Excel when saving CSV/TSV, is stripped before parsing so it
+ * doesn't get glued onto the first header name (e.g. "\uFEFFColor"), which
+ * would otherwise make every row's Color column look missing.
+ *
  * Returns null if the input has no header, no valid data rows, or cannot be
  * parsed.
  */
@@ -408,6 +413,8 @@ export function parseHueForgeCSV(
     csv: string,
     profileName = 'HueForge Import'
 ): AutoPaintProfile[] | null {
+    if (csv.charCodeAt(0) === 0xfeff) csv = csv.slice(1);
+
     const firstNewline = csv.indexOf('\n');
     const headerLine = firstNewline >= 0 ? csv.slice(0, firstNewline) : csv;
     const delimiter = detectDelimiter(headerLine);

--- a/tests/profileManager.test.ts
+++ b/tests/profileManager.test.ts
@@ -199,6 +199,30 @@ Overture Basic,#033877,Blue,3.5`;
     assert.equal(profile.filaments[0].td, 0.35);
 });
 
+test('parseHueForgeCSV strips a leading UTF-8 BOM before parsing the header', () => {
+    // A UTF-8 BOM (U+FEFF) is often prepended by spreadsheet tools (e.g.
+    // Excel) when saving CSV/TSV. Without stripping it, the first header
+    // cell reads as "\uFEFFColor" instead of "Color", so the Color column
+    // lookup fails for every row and no filaments are imported.
+    const csv = `\uFEFFColor,TD,Name
+#bf9c81,1.7,Light Brown`;
+    const profiles = parseHueForgeCSV(csv, 'My Spools');
+    assert.ok(profiles);
+    assert.equal(profiles.length, 1);
+    assert.equal(profiles[0].filaments.length, 1);
+    assert.equal(profiles[0].filaments[0].color, '#BF9C81');
+    assert.equal(profiles[0].filaments[0].td, 0.17);
+});
+
+test('parseHueForgeCSV strips a leading UTF-8 BOM from TSV input as well', () => {
+    const tsv = `\uFEFFBrand\tColor\tName\tTD
+Inland Basic\t#bf9c81\tLight Brown\t1.7`;
+    const [profile] = parseHueForgeCSV(tsv)!;
+    assert.equal(profile.filaments.length, 1);
+    assert.equal(profile.filaments[0].color, '#BF9C81');
+    assert.equal(profile.filaments[0].brand, 'Inland Basic');
+});
+
 test('auto-paint profiles can be renamed without changing filament data', async () => {
     const { renameProfile } = await loadProfileManager();
     const profiles: AutoPaintProfile[] = [


### PR DESCRIPTION
## What / Why

Fixes #42: `parseHueForgeCSV` matches column names literally, so a UTF-8 BOM on the first header (common when a spreadsheet tool like Excel saves CSV/TSV) makes a file beginning with `Color,TD,...` decode its first header cell as `\uFEFFColor` instead of `Color`. The `Color` column lookup then never matches for any row, and no filaments get imported — the file just silently produces nothing.

## Fix

Strip a single leading `U+FEFF` code unit from the CSV/TSV string before parsing starts, so the header row decodes identically whether or not the source file carries a BOM. This only touches the very first character of the input and is a no-op for files without one.

## Testing

```
npm ci
npm run test     # 341/341 pass, 0 fail (full existing suite + 2 new tests)
npx eslint . --ext .ts,.tsx --max-warnings=0 src/lib/profileManager.ts tests/profileManager.test.ts
npx tsc -b --noEmit
```

Added two regression tests to `tests/profileManager.test.ts` (targets `develop`'s `parseHueForgeCSV`, introduced in #37):
- `strips a leading UTF-8 BOM before parsing the header` — a CSV with `\uFEFFColor,TD,Name` as its header now imports correctly, reproducing #42's exact failure mode as the issue requested.
- `strips a leading UTF-8 BOM from TSV input as well` — same fix verified on the tab-delimited path, since `detectDelimiter`/`parseCSV` are shared between CSV and TSV.

Fixes #42
